### PR TITLE
Hot fix mobile number, replace space with nothing

### DIFF
--- a/app/Http/Controllers/InitialisationController.php
+++ b/app/Http/Controllers/InitialisationController.php
@@ -82,6 +82,10 @@ class InitialisationController extends Controller
      */
     public function request($locationId, Request $request)
     {
+        if($request->has('phone_mobile')) {
+            $request->merge(['phone_mobile' => preg_replace('/\s+/', '', $request->get('phone_mobile'))]);
+        }
+
         $this->validate(
             $request,
             [


### PR DESCRIPTION
## Bug Fixes
- Fixed spaces in the `mobile_number` not working for alternate applications

[Delivers [#127916831](https://www.pivotaltracker.com/story/show/127916831)]